### PR TITLE
Add fsGroupChangePolicy to JupyterHub singleuser config

### DIFF
--- a/MAIA_scripts/MAIA_create_JupyterHub_config.py
+++ b/MAIA_scripts/MAIA_create_JupyterHub_config.py
@@ -229,6 +229,7 @@ def create_jupyterhub_config_api(form, cluster_config_file, config_folder=None, 
             "startTimeout": 7200,
             "allowPrivilegeEscalation": True,
             "uid": 1000,
+            "extraPodConfig": {"securityContext": {"fsGroupChangePolicy": "OnRootMismatch"}},
             "networkPolicy": {"enabled": False},
             "defaultUrl": "/lab/tree/Welcome.ipynb",
             "extraEnv": {


### PR DESCRIPTION
## Summary
- Add `extraPodConfig.securityContext.fsGroupChangePolicy: OnRootMismatch` to the JupyterHub singleuser config to avoid slow recursive chown on CIFS volumes during pod startup. Without this, the kubelet recursively sets ownership on all files in the CIFS share, which can take minutes and cause pod sync timeouts.